### PR TITLE
[Forwardport] Resolved : no navigation-level0-item__hover__color #15848

### DIFF
--- a/app/code/Magento/Backend/Test/Mftf/Section/AdminMessagesSection.xml
+++ b/app/code/Magento/Backend/Test/Mftf/Section/AdminMessagesSection.xml
@@ -11,5 +11,6 @@
     <section name="AdminMessagesSection">
         <element name="success" type="text" selector="#messages div.message-success"/>
         <element name="nthSuccess" type="text" selector=".message.message-success.success:nth-of-type({{n}})>div" parameterized="true"/>
+        <element name="error" type="text" selector="#messages div.message-error"/>
     </section>
 </sections>

--- a/app/code/Magento/Bundle/Test/Mftf/Test/EnableDisableBundleProductStatusTest.xml
+++ b/app/code/Magento/Bundle/Test/Mftf/Test/EnableDisableBundleProductStatusTest.xml
@@ -75,11 +75,16 @@
         <seeElement stepKey="LookingForNameOfProduct" selector="{{BundleStorefrontSection.bundleProductName}}"/>
 
         <!--Testing disabled view-->
-        <actionGroup ref="FindProductToEdit" stepKey="FindProductEditPage"/>
+        <amOnPage url="{{AdminProductIndexPage.url}}" stepKey="GoToProductCatalog"/>
+        <waitForPageLoad stepKey="WaitForCatalogProductPageToLoad"/>
+        <actionGroup ref="filterProductGridBySku" stepKey="FindProductEditPage">
+            <argument name="product" value="BundleProduct"/>
+        </actionGroup>
+        <click selector="{{AdminDataGridTableSection.rowViewAction('1')}}" stepKey="ClickProductInGrid"/>
         <click stepKey="ClickOnEnableDisableToggle" selector="{{AdminProductFormBundleSection.enableDisableToggle}}"/>
         <click selector="{{AdminProductFormActionSection.saveButton}}" stepKey="clickSaveButtonAgain"/>
-        <seeElement selector="{{AdminCategoryMessagesSection.SuccessMessage}}" stepKey="messageYouSavedTheProductIsShown2"/>
         <waitForPageLoad stepKey="PauseForSave"/>
+        <see selector="{{AdminCategoryMessagesSection.SuccessMessage}}" userInput="You saved the product." stepKey="messageYouSavedTheProductIsShownAgain"/>
         <amOnPage url="{{BundleProduct.urlKey}}.html" stepKey="GoToProductPageAgain"/>
         <waitForPageLoad stepKey="WaitForProductPageToLoadToShowElement"/>
         <dontSeeElement stepKey="LookingForNameOfProductTwo" selector="{{BundleStorefrontSection.bundleProductName}}"/>

--- a/app/code/Magento/Sales/Test/Mftf/Section/AdminCreditMemoTotalSection.xml
+++ b/app/code/Magento/Sales/Test/Mftf/Section/AdminCreditMemoTotalSection.xml
@@ -10,7 +10,7 @@
         xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Page/etc/SectionObject.xsd">
     <section name="AdminCreditMemoTotalSection">
         <element name="subtotalRow" type="text" selector=".order-subtotal-table tbody > tr:nth-of-type({{row}}) td span.price" parameterized="true"/>
-        <element name="total" type="text" selector="//table[contains(@class,'order-subtotal-table')]/tbody/tr/td[contains(text(), '{{total}}')]/following-sibling::td/span/span[contains(@class, 'price')]" parameterized="true"/>
+        <element name="total" type="text" selector="//table[contains(@class,'order-subtotal-table')]/tbody/tr/td[contains(text(), '{{total}}')]/following-sibling::td//span[contains(@class, 'price')]" parameterized="true"/>
         <element name="refundShipping" type="input" selector=".order-subtotal-table tbody input[name='creditmemo[shipping_amount]']"/>
         <element name="adjustmentRefund" type="input" selector=".order-subtotal-table tbody input[name='creditmemo[adjustment_positive]'"/>
         <element name="adjustmentFee" type="input" selector=".order-subtotal-table tbody input[name='creditmemo[adjustment_negative]']"/>

--- a/app/code/Magento/Sales/Test/Mftf/Section/AdminOrderCreditMemosTabSection.xml
+++ b/app/code/Magento/Sales/Test/Mftf/Section/AdminOrderCreditMemosTabSection.xml
@@ -12,5 +12,6 @@
         <element name="spinner" type="text" selector="[data-role='spinner'][data-component*='sales_order_view_creditmemo']"/>
         <element name="gridRow" type="text" selector="#sales_order_view_tabs_order_creditmemos_content .data-grid tbody > tr:nth-of-type({{row}})" parameterized="true"/>
         <element name="viewGridRow" type="button" selector="#sales_order_view_tabs_order_creditmemos_content .data-grid tbody > tr:nth-of-type({{row}}) a[href*='order_creditmemo/view']" parameterized="true"/>
+        <element name="gridRowCell" type="text" selector="//div[@id='sales_order_view_tabs_order_creditmemos_content']//tr[{{row}}]//td[count(//div[@id='sales_order_view_tabs_order_creditmemos_content']//tr//th[contains(., '{{column}}')][1]/preceding-sibling::th) +1 ]" parameterized="true"/>
     </section>
 </sections>

--- a/lib/internal/Magento/Framework/Math/FloatComparator.php
+++ b/lib/internal/Magento/Framework/Math/FloatComparator.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Framework\Math;
+
+/**
+ * Contains methods to compare float digits.
+ *
+ * @api
+ */
+class FloatComparator
+{
+    /**
+     * Precision for floats comparing.
+     *
+     * @var float
+     */
+    private static $epsilon = 0.00001;
+
+    /**
+     * Compares two float digits.
+     *
+     * @param float $a
+     * @param float $b
+     * @return bool
+     */
+    public function equal(float $a, float $b): bool
+    {
+        return abs($a - $b) <= self::$epsilon;
+    }
+
+    /**
+     * Compares if the first argument greater than the second argument.
+     *
+     * @param float $a
+     * @param float $b
+     * @return bool
+     */
+    public function greaterThan(float $a, float $b): bool
+    {
+        return ($a - $b) > self::$epsilon;
+    }
+
+    /**
+     * Compares if the first argument greater or equal to the second.
+     *
+     * @param float $a
+     * @param float $b
+     * @return bool
+     */
+    public function greaterThanOrEqual(float $a, float $b): bool
+    {
+        return $this->equal($a, $b) || $this->greaterThan($a, $b);
+    }
+}

--- a/lib/internal/Magento/Framework/Math/Test/Unit/FloatComparatorTest.php
+++ b/lib/internal/Magento/Framework/Math/Test/Unit/FloatComparatorTest.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Framework\Math\Test\Unit;
+
+use Magento\Framework\Math\FloatComparator;
+use PHPUnit\Framework\TestCase;
+
+class FloatComparatorTest extends TestCase
+{
+    /**
+     * @var FloatComparator
+     */
+    private $comparator;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->comparator = new FloatComparator();
+    }
+
+    /**
+     * Checks a case when `a` and `b` are equal.
+     *
+     * @param float $a
+     * @param float $b
+     * @param bool $expected
+     * @dataProvider eqDataProvider
+     */
+    public function testEq(float $a, float $b, bool $expected)
+    {
+        self::assertEquals($expected, $this->comparator->equal($a, $b));
+    }
+
+    /**
+     * Gets list of variations to compare equal float.
+     *
+     * @return array
+     */
+    public function eqDataProvider(): array
+    {
+        return [
+            [10, 10.00001, true],
+            [10, 10.000001, true],
+            [10.0000099, 10.00001, true],
+            [1, 1.0001, false],
+            [1, -1.00001, false],
+        ];
+    }
+
+    /**
+     * Checks a case when `a` > `b`.
+     *
+     * @param float $a
+     * @param float $b
+     * @param bool $expected
+     * @dataProvider gtDataProvider
+     */
+    public function testGt(float $a, float $b, bool $expected)
+    {
+        self::assertEquals($expected, $this->comparator->greaterThan($a, $b));
+    }
+
+    /**
+     * Gets list of variations to compare if `a` > `b`.
+     *
+     * @return array
+     */
+    public function gtDataProvider(): array
+    {
+        return [
+            [10, 10.00001, false],
+            [10, 10.000001, false],
+            [10.0000099, 10.00001, false],
+            [1.0001, 1, true],
+            [1, -1.00001, true],
+        ];
+    }
+
+    /**
+     * Checks a case when `a` >= `b`.
+     *
+     * @param float $a
+     * @param float $b
+     * @param bool $expected
+     * @dataProvider gteDataProvider
+     */
+    public function testGte(float $a, float $b, bool $expected)
+    {
+        self::assertEquals($expected, $this->comparator->greaterThanOrEqual($a, $b));
+    }
+
+    /**
+     * Gets list of variations to compare if `a` >= `b`.
+     *
+     * @return array
+     */
+    public function gteDataProvider(): array
+    {
+        return [
+            [10, 10.00001, true],
+            [10, 10.000001, true],
+            [10.0000099, 10.00001, true],
+            [1.0001, 1, true],
+            [1, -1.00001, true],
+            [1.0001, 1.001, false],
+        ];
+    }
+}

--- a/lib/web/css/source/lib/_navigation.less
+++ b/lib/web/css/source/lib/_navigation.less
@@ -92,6 +92,9 @@
                 .lib-css(padding, @_nav-level0-item-padding);
                 .lib-css(text-transform, @_nav-level0-text-transform);
                 word-wrap: break-word;
+                &:hover {
+                    .lib-css(color, @navigation-level0-item__hover__color);
+                }
             }
 
             &.active {
@@ -139,6 +142,11 @@
         .submenu {
             > li {
                 word-wrap: break-word;
+                > a {
+                    &:hover {
+                        .lib-css(color, @navigation-level0-item__hover__color);
+                    }
+                }
             }
 
             &:not(:first-child) {
@@ -178,6 +186,9 @@
                             .lib-css(text-decoration, @_submenu-item-text-decoration);
                             display: block;
                             line-height: normal;
+                            &:hover {
+                                .lib-css(color, @navigation-level0-item__hover__color);
+                            }
                         }
                     }
                 }

--- a/lib/web/css/source/lib/variables/_navigation.less
+++ b/lib/web/css/source/lib/variables/_navigation.less
@@ -28,6 +28,7 @@
 @navigation-level0-item__active__border-width: 0 0 0 8px;
 @navigation-level0-item__active__color: '';
 @navigation-level0-item__active__text-decoration: '';
+@navigation-level0-item__hover__color: @primary__color;
 
 @submenu__background: '';
 @submenu__border: '';


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16732
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description

I have added `@navigation-level0-item__hover__color` missing variable for mobile and tablet view.

<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://github.com/magento/magento2/issues/15848: no navigation-level0-item__hover__color

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
