### PR TITLE
[Forwardport] Prevent servers being slammed from many search suggestion requests

### DIFF
--- a/app/code/Magento/Search/view/frontend/web/form-mini.js
+++ b/app/code/Magento/Search/view/frontend/web/form-mini.js
@@ -43,7 +43,8 @@ define([
                 '</li>',
             submitBtn: 'button[type="submit"]',
             searchLabel: '[data-role=minisearch-label]',
-            isExpandable: null
+            isExpandable: null,
+            suggestionDelay: 250
         },
 
         /** @inheritdoc */
@@ -104,7 +105,8 @@ define([
 
             this.element.on('focus', this.setActiveState.bind(this, true));
             this.element.on('keydown', this._onKeyDown);
-            this.element.on('input propertychange', this._onPropertyChange);
+            // Prevent spamming the server with requests by waiting till the user has stopped typing for period of time
+            this.element.on('input propertychange', _.debounce(this._onPropertyChange, this.options.suggestionDelay));
 
             this.searchForm.on('submit', $.proxy(function (e) {
                 this._onSubmit(e);

--- a/app/code/Magento/Search/view/frontend/web/form-mini.js
+++ b/app/code/Magento/Search/view/frontend/web/form-mini.js
@@ -44,7 +44,7 @@ define([
             submitBtn: 'button[type="submit"]',
             searchLabel: '[data-role=minisearch-label]',
             isExpandable: null,
-            suggestionDelay: 250
+            suggestionDelay: 300
         },
 
         /** @inheritdoc */


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16669
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Currently when a customer is typing in the search suggestion box, every character that is typed is immediately sent to the server. Typical auto-complete boxes will have a delay before sending the request to ensure this doesn't happen. This PR simply uses underscore's debounce method to throttle the requests with a default amount of 300ms, following the default configuration of jQuery's delay method: https://api.jqueryui.com/autocomplete/#option-delay

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/community-features#71

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
